### PR TITLE
Fix non-deterministic directory traversal

### DIFF
--- a/appbundle/file_system.go
+++ b/appbundle/file_system.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 )
 
@@ -33,6 +34,9 @@ func AnalyzeFile(filePath string, basePath string) (core.FileInfo, error) {
 		if err != nil {
 			return core.FileInfo{}, fmt.Errorf("failed to read directory: %v", err)
 		}
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Name() < entries[j].Name()
+		})
 
 		var totalSize int64
 		var childChecksums []string


### PR DESCRIPTION
## Summary
- sort directory entries in `AnalyzeFile` so directory checksums are repeatable

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6844691d0c988320a6b0f7e44ff2bfd0