### PR TITLE
Check cwebp before image conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,4 @@ bitrise :diff old.json new.json --json=diff.json
 - macOS (required for iOS app bundle analysis)
 - Bitrise CLI installed
 - For analyzing .ipa files: ability to extract and process iOS app bundles
+- For analyzing Android images: the `cwebp` command must be installed

--- a/appbundle/android/image.go
+++ b/appbundle/android/image.go
@@ -69,11 +69,15 @@ func AnalyzeImages(bundleDir string, manifest android.AndroidManifest) ([]core.O
 }
 
 func convertToWebP(imagePath string) (int64, int64, error) {
+	if _, err := exec.LookPath("cwebp"); err != nil {
+		return 0, 0, fmt.Errorf("cwebp not found: please install it to analyze images")
+	}
+
 	tmpDir, err := os.MkdirTemp("", "webp-conversion")
-	defer (func() { os.RemoveAll(tmpDir) })()
 	if err != nil {
 		return 0, 0, err
 	}
+	defer (func() { os.RemoveAll(tmpDir) })()
 
 	tmpFile := filepath.Join(tmpDir, "converted.webp")
 


### PR DESCRIPTION
## Summary
- ensure the cwebp tool is present before converting images to WebP
- document cwebp requirement in README

## Testing
- `go vet ./...`
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68446936d53c8320b224e614d00a9635