### PR TITLE
Update ParseAndroidManifest search path logic

### DIFF
--- a/appbundle/android/android_manifest.go
+++ b/appbundle/android/android_manifest.go
@@ -13,12 +13,37 @@ import (
 func ParseAndroidManifest(apkPath string) (android.AndroidManifest, error) {
 	var manifest android.AndroidManifest
 
-	// Path to the apkanalyzer tool
-	apkanalyzerPath := filepath.Join(os.Getenv("HOME"), "Library/Android/sdk/cmdline-tools/latest/bin/apkanalyzer")
+	var searchPaths []string
+	var apkanalyzerPath string
 
-	// Check if apkanalyzer exists
-	if _, err := os.Stat(apkanalyzerPath); os.IsNotExist(err) {
-		return manifest, fmt.Errorf("apkanalyzer not found at %s", apkanalyzerPath)
+	if sdkRoot := os.Getenv("ANDROID_SDK_ROOT"); sdkRoot != "" {
+		candidate := filepath.Join(sdkRoot, "cmdline-tools/latest/bin/apkanalyzer")
+		searchPaths = append(searchPaths, candidate)
+		if _, err := os.Stat(candidate); err == nil {
+			apkanalyzerPath = candidate
+		}
+	}
+
+	if apkanalyzerPath == "" {
+		if androidHome := os.Getenv("ANDROID_HOME"); androidHome != "" {
+			candidate := filepath.Join(androidHome, "cmdline-tools/latest/bin/apkanalyzer")
+			searchPaths = append(searchPaths, candidate)
+			if _, err := os.Stat(candidate); err == nil {
+				apkanalyzerPath = candidate
+			}
+		}
+	}
+
+	if apkanalyzerPath == "" {
+		candidate := filepath.Join(os.Getenv("HOME"), "Library/Android/sdk/cmdline-tools/latest/bin/apkanalyzer")
+		searchPaths = append(searchPaths, candidate)
+		if _, err := os.Stat(candidate); err == nil {
+			apkanalyzerPath = candidate
+		}
+	}
+
+	if apkanalyzerPath == "" {
+		return manifest, fmt.Errorf("apkanalyzer not found. searched: %s", strings.Join(searchPaths, ", "))
 	}
 
 	// Prepare the command to extract AndroidManifest.xml


### PR DESCRIPTION
## Summary
- check `ANDROID_SDK_ROOT` and `ANDROID_HOME` for `apkanalyzer`
- fall back to the previous default path if needed
- include searched locations in the error message

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_684573f61f148320bdca9f2d4ab5f68d