### PR TITLE
Make Python interpreter configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,3 +104,8 @@ bitrise :diff old.json new.json --json=diff.json
 - Bitrise CLI installed
 - For analyzing .ipa files: ability to extract and process iOS app bundles
 - For analyzing Android images: the `cwebp` command must be installed
+
+### Environment Variables
+
+- `PYTHON_BIN`: Path to the Python interpreter used to create the temporary
+  virtual environment. Defaults to `python3`.

--- a/appbundle/python/python.go
+++ b/appbundle/python/python.go
@@ -38,6 +38,16 @@ func (env *PythonEnvironment) isSetup() bool {
 	return env.DirPath != ""
 }
 
+// pythonInterpreter returns the Python binary to use when creating the
+// virtual environment. It reads the path from the PYTHON_BIN environment
+// variable and falls back to "python3" if not set.
+func pythonInterpreter() string {
+	if bin := os.Getenv("PYTHON_BIN"); bin != "" {
+		return bin
+	}
+	return "python3"
+}
+
 // Cleanup removes the temporary virtual environment directory
 func (env *PythonEnvironment) Cleanup() {
 	if env.DirPath != "" {
@@ -69,7 +79,7 @@ func (env *PythonEnvironment) SetupPythonEnvironment() error {
 	// Create venv if it doesn't exist
 	if _, err := os.Stat(env.PythonBin()); os.IsNotExist(err) {
 		fmt.Println("  Creating virtual environment...")
-		cmd := exec.Command("python3.11", "-m", "venv", env.VenvDir())
+		cmd := exec.Command(pythonInterpreter(), "-m", "venv", env.VenvDir())
 		if out, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("venv creation failed: %w\nOutput: %s", err, out)
 		}


### PR DESCRIPTION
## Summary
- allow overriding Python binary with `PYTHON_BIN`
- document `PYTHON_BIN` in the README

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6845741966a083209d4128b87ae1d532