### PR TITLE
Add progress bar for bundle analysis

### DIFF
--- a/appbundle/appbundle.go
+++ b/appbundle/appbundle.go
@@ -7,13 +7,16 @@ import (
 	"bitrise-plugins-analyze/appbundle/ios"
 	"bitrise-plugins-analyze/appbundle/python"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	progressbar "github.com/schollz/progressbar/v3"
 )
 
-func Analyze(bundle_path string) (*core.AppBundle, error) {
+func Analyze(bundle_path string, progressWriter io.Writer) (*core.AppBundle, error) {
 	ext := strings.ToLower(filepath.Ext(bundle_path))
 
 	var err error
@@ -36,25 +39,45 @@ func Analyze(bundle_path string) (*core.AppBundle, error) {
 	if err != nil {
 		return nil, err
 	}
-	return analyzeAppBundle(tmp_path)
+
+	fileCount, err := countFiles(tmp_path)
+	if err != nil {
+		return nil, err
+	}
+
+	var bar *progressbar.ProgressBar
+	if progressWriter != nil {
+		bar = progressbar.NewOptions(fileCount,
+			progressbar.OptionSetWriter(progressWriter),
+			progressbar.OptionShowCount(),
+			progressbar.OptionClearOnFinish(),
+			progressbar.OptionSetDescription("Analyzing"),
+		)
+	}
+
+	bundle, err := analyzeAppBundle(tmp_path, bar)
+	if bar != nil {
+		bar.Finish()
+	}
+	return bundle, err
 }
 
 // AnalyzeAppBundle analyzes the provided app bundle directory and returns the analysis results
-func analyzeAppBundle(bundlePath string) (*core.AppBundle, error) {
+func analyzeAppBundle(bundlePath string, bar *progressbar.ProgressBar) (*core.AppBundle, error) {
 	bundle := &core.AppBundle{}
 	var err error
 
 	ext := strings.ToLower(filepath.Ext(bundlePath))
 	switch ext {
 	case core.AppExtension:
-		err = analyzeiOSApp(bundlePath, bundle)
+		err = analyzeiOSApp(bundlePath, bundle, bar)
 	case core.ApkExtension:
-		err = analyzeAndroidApp(bundlePath, bundle)
+		err = analyzeAndroidApp(bundlePath, bundle, bar)
 	}
 	return bundle, err
 }
 
-func analyzeiOSApp(bundlePath string, bundle *core.AppBundle) error {
+func analyzeiOSApp(bundlePath string, bundle *core.AppBundle, bar *progressbar.ProgressBar) error {
 	files, err := AnalyzeFile(bundlePath, bundlePath)
 	if err != nil {
 		return err
@@ -96,6 +119,10 @@ func analyzeiOSApp(bundlePath string, bundle *core.AppBundle) error {
 
 		if info.IsDir() {
 			return nil
+		}
+
+		if bar != nil {
+			bar.Add(1)
 		}
 
 		switch filepath.Ext(strings.ToLower(path)) {
@@ -144,7 +171,7 @@ func analyzeiOSApp(bundlePath string, bundle *core.AppBundle) error {
 	return nil
 }
 
-func analyzeAndroidApp(bundlePath string, bundle *core.AppBundle) error {
+func analyzeAndroidApp(bundlePath string, bundle *core.AppBundle, bar *progressbar.ProgressBar) error {
 	// Analyze AndroidManifest.xml
 	manifest, err := android.ParseAndroidManifest(bundlePath)
 	if err != nil {
@@ -187,6 +214,10 @@ func analyzeAndroidApp(bundlePath string, bundle *core.AppBundle) error {
 
 		if info.IsDir() {
 			return nil
+		}
+
+		if bar != nil {
+			bar.Add(1)
 		}
 
 		switch filepath.Ext(strings.ToLower(path)) {
@@ -256,4 +287,18 @@ func analyzeAndroidApp(bundlePath string, bundle *core.AppBundle) error {
 	bundle.DownloadSize = apkInfo.Size()
 
 	return nil
+}
+
+func countFiles(root string) (int, error) {
+	count := 0
+	err := filepath.Walk(root, func(_ string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			count++
+		}
+		return nil
+	})
+	return count, err
 }

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"golang.org/x/term"
+
 	"github.com/spf13/cobra"
 )
 
@@ -48,7 +50,12 @@ var analyzeCmd = &cobra.Command{
 			return errors.New("app_path is empty")
 		}
 
-		bundle, err := appbundle.Analyze(app_path)
+		var progressWriter io.Writer
+		if term.IsTerminal(int(os.Stdout.Fd())) {
+			progressWriter = os.Stdout
+		}
+
+		bundle, err := appbundle.Analyze(app_path, progressWriter)
 		if err != nil {
 			return err
 		}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module bitrise-plugins-analyze
 go 1.21
 
 require (
-	github.com/spf13/cobra v1.9.1
-	howett.net/plist v1.0.1
+        github.com/spf13/cobra v1.9.1
+        howett.net/plist v1.0.1
+       github.com/schollz/progressbar/v3 v3.13.0
+       golang.org/x/term v0.15.0
 )
 
 require (


### PR DESCRIPTION
## Summary
- show file analysis progress with progressbar
- hide progress bar when output is not a terminal
- wire up progress bar in CLI
- add new dependencies

## Testing
- `go mod tidy` *(fails: module downloads blocked)*
- `go vet ./...` *(fails: missing module due to lack of network access)*

------
https://chatgpt.com/codex/tasks/task_e_685a7c681fc083208566a5bae3a75428